### PR TITLE
Update tests to the latest oatpp 1.4.0 API

### DIFF
--- a/test/tests.cpp
+++ b/test/tests.cpp
@@ -10,7 +10,7 @@ public:
   {}
 
   void onRun() override {
-    OATPP_LOGD(TAG, "Hello Test");
+    OATPP_LOGd(TAG, "Hello Test");
     // TODO write correct  tests
   }
 };
@@ -23,19 +23,19 @@ void runTests() {
 
 int main() {
 
-  oatpp::base::Environment::init();
+  oatpp::Environment::init();
 
   runTests();
 
   /* Print how much objects were created during app running, and what have left-probably leaked */
   /* Disable object counting for release builds using '-D OATPP_DISABLE_ENV_OBJECT_COUNTERS' flag for better performance */
   std::cout << "\nEnvironment:\n";
-  std::cout << "objectsCount = " << oatpp::base::Environment::getObjectsCount() << "\n";
-  std::cout << "objectsCreated = " << oatpp::base::Environment::getObjectsCreated() << "\n\n";
+  std::cout << "objectsCount = " << oatpp::Environment::getObjectsCount() << "\n";
+  std::cout << "objectsCreated = " << oatpp::Environment::getObjectsCreated() << "\n\n";
 
-  OATPP_ASSERT(oatpp::base::Environment::getObjectsCount() == 0);
+  OATPP_ASSERT(oatpp::Environment::getObjectsCount() == 0);
 
-  oatpp::base::Environment::destroy();
+  oatpp::Environment::destroy();
 
   return 0;
 }


### PR DESCRIPTION
I've followed the README instructions and had the following errors:

```bash
[ 87%] Building CXX object CMakeFiles/hls-example-test.dir/test/tests.cpp.o
/home/aboud/sandbox/example-hls-media-stream/test/tests.cpp: In member function ‘virtual void {anonymous}::Test::onRun()’:
/home/aboud/sandbox/example-hls-media-stream/test/tests.cpp:13:5: error: ‘OATPP_LOGD’ was not declared in this scope; did you mean ‘OATPP_LOGd’?
   13 |     OATPP_LOGD(TAG, "Hello Test");
      |     ^~~~~~~~~~
      |     OATPP_LOGd
/home/aboud/sandbox/example-hls-media-stream/test/tests.cpp: In function ‘int main()’:
/home/aboud/sandbox/example-hls-media-stream/test/tests.cpp:26:16: error: ‘oatpp::base::Environment’ has not been declared
   26 |   oatpp::base::Environment::init();
      |                ^~~~~~~~~~~
/home/aboud/sandbox/example-hls-media-stream/test/tests.cpp:33:50: error: ‘oatpp::base::Environment’ has not been declared
   33 |   std::cout << "objectsCount = " << oatpp::base::Environment::getObjectsCount() << "\n";
      |                                                  ^~~~~~~~~~~
/home/aboud/sandbox/example-hls-media-stream/test/tests.cpp:34:52: error: ‘oatpp::base::Environment’ has not been declared
   34 |   std::cout << "objectsCreated = " << oatpp::base::Environment::getObjectsCreated() << "\n\n";
      |                                                    ^~~~~~~~~~~
In file included from /usr/local/include/oatpp-1.4.0/oatpp/oatpp-test/UnitTest.hpp:29,
                 from /home/aboud/sandbox/example-hls-media-stream/test/tests.cpp:2:
/home/aboud/sandbox/example-hls-media-stream/test/tests.cpp:36:29: error: ‘oatpp::base::Environment’ has not been declared
   36 |   OATPP_ASSERT(oatpp::base::Environment::getObjectsCount() == 0);
      |                             ^~~~~~~~~~~
/home/aboud/sandbox/example-hls-media-stream/test/tests.cpp:38:16: error: ‘oatpp::base::Environment’ has not been declared
   38 |   oatpp::base::Environment::destroy();
      |                ^~~~~~~~~~~
make[2]: *** [CMakeFiles/hls-example-test.dir/build.make:76: CMakeFiles/hls-example-test.dir/test/tests.cpp.o] Error 1
make[1]: *** [CMakeFiles/Makefile2:139: CMakeFiles/hls-example-test.dir/all] Error 2
make: *** [Makefile:101: all] Error 2
```

Apparently, the `tests.cpp` file was not updated to the `1.4.0` version on the commit: https://github.com/oatpp/example-hls-media-stream/commit/afcb50f12abb3de6bfe6f8842898d26a4a6e4180

With these changes, the build ran successfully.